### PR TITLE
Allow encoded strings in basic auth

### DIFF
--- a/webtest_plus/app.py
+++ b/webtest_plus/app.py
@@ -5,12 +5,20 @@ import webtest
 from webtest import utils
 
 from webtest_plus.response import TestResponse
-from webtest_plus.compat import PY2, binary_type
+from webtest_plus.compat import PY2, binary_type, unicode
 
 
 def _basic_auth_str(username, password):
     """Returns a Basic Auth string."""
-    return 'Basic ' + b64encode(('%s:%s' % (username, password)).encode('latin1')).strip().decode('latin1')
+    if isinstance(username, unicode):
+        username = username.encode('latin1')
+
+    if isinstance(password, unicode):
+        password = password.encode('latin1')
+
+    return b'Basic ' + (
+        b64encode(b':'.join((username, password))).strip()
+    )
 
 
 def _add_auth(auth, headers, auth_type='basic'):


### PR DESCRIPTION
Fixes https://github.com/sloria/webtest-plus/issues/3

Unfortunately, werkzeug fails to decode such a string properly as it also forces latin1 encoding by default, so it's impossible to test this fix with current test flask app without fixing werkzeug first or providing custom basic auth parser. (see https://github.com/pallets/werkzeug/blob/e4730eff5d52d335f802992e4bc953e5fee1b586/werkzeug/http.py#L467)
Currently I don't have any more time to work on this, I can only confirm that it works properly in a falcon based stack.